### PR TITLE
Minor FPS gains

### DIFF
--- a/config.h
+++ b/config.h
@@ -238,11 +238,3 @@
 #ifndef CONFIG_APU_N_BUFSIZE
 #define CONFIG_APU_N_BUFSIZE 32768
 #endif
-
-#if defined(__GNUC__) || defined(__clang__)
-    #define LIKELY(x)   (__builtin_expect(!!(x), 1))
-    #define UNLIKELY(x) (__builtin_expect(!!(x), 0))
-#else
-    #define LIKELY(x)   (x)
-    #define UNLIKELY(x) (x)
-#endif

--- a/config.h
+++ b/config.h
@@ -238,3 +238,11 @@
 #ifndef CONFIG_APU_N_BUFSIZE
 #define CONFIG_APU_N_BUFSIZE 32768
 #endif
+
+#if defined(__GNUC__) || defined(__clang__)
+    #define LIKELY(x)   (__builtin_expect(!!(x), 1))
+    #define UNLIKELY(x) (__builtin_expect(!!(x), 0))
+#else
+    #define LIKELY(x)   (x)
+    #define UNLIKELY(x) (x)
+#endif

--- a/fabric.c
+++ b/fabric.c
@@ -12,7 +12,12 @@
 
 PGB_FUNC const r8* pgf_resolve_ROM(void* userdata, word addr, word bank)
 {
+    #if CONFIG_ENABLE_LRU
     return pgf_resolve_ROM_internal(userdata, addr, bank);
+    #else
+    USE_UD;
+    return ud->mb->mi->ROMBASE + 0x4000 * bank + (addr & 0x3FFF);
+    #endif
 }
 
 //#include "profi.h"

--- a/fabric.h
+++ b/fabric.h
@@ -71,7 +71,7 @@ static inline const r8* pgf_resolve_ROM_internal(void* userdata, word addr, word
     if(ud->mb->mi->ROM)
 #endif
     {
-        res = ud->mb->mi->ROM[bank];
+        res = ud->mb->mi->ROMBASE + 0x4000 * bank;
         if(res)
             return &res[addr & 0x3FFF];
     }

--- a/fabric.h
+++ b/fabric.h
@@ -72,12 +72,14 @@ static inline const r8* pgf_resolve_ROM_internal(void* userdata, word addr, word
 #endif
     {
         #if CONFIG_ENABLE_LRU
-            res = ud->mb->mi->ROM[bank]
+            res = ud->mb->mi->ROM[bank];
+            if (res)
+                return &res[addr & 0x3FFF];
         #else
             res = ud->mb->mi->ROMBASE + 0x4000 * bank;
-        #endif
-        if(res)
             return &res[addr & 0x3FFF];
+        #endif
+            
     }
     
 #if CONFIG_ENABLE_LRU

--- a/fabric.h
+++ b/fabric.h
@@ -53,7 +53,8 @@ static inline void pgf_timer_update(struct pgf_userdata_t* __restrict ud, word c
     if UNLIKELY(ud->TIMER_ACCUM >= 0x10000)
     {
         ud->mb->IF |= 4;
-        ud->TIMER_ACCUM = ud->TIMER_LOAD;
+        word remainder = 0x10000 - ud->TIMER_LOAD;
+        ud->TIMER_ACCUM = ud->TIMER_LOAD + ((ud->TIMER_INC * cycles) % remainder);
     }
 }
 

--- a/fabric.h
+++ b/fabric.h
@@ -71,7 +71,11 @@ static inline const r8* pgf_resolve_ROM_internal(void* userdata, word addr, word
     if(ud->mb->mi->ROM)
 #endif
     {
+        #if CONFIG_ENABLE_LRU
         res = ud->mb->mi->ROMBASE + 0x4000 * bank;
+        #else
+        res = ud->mb->mi->ROM[bank]
+        #endif
         if(res)
             return &res[addr & 0x3FFF];
     }

--- a/fabric.h
+++ b/fabric.h
@@ -72,9 +72,9 @@ static inline const r8* pgf_resolve_ROM_internal(void* userdata, word addr, word
 #endif
     {
         #if CONFIG_ENABLE_LRU
-        res = ud->mb->mi->ROMBASE + 0x4000 * bank;
+            res = ud->mb->mi->ROM[bank]
         #else
-        res = ud->mb->mi->ROM[bank]
+            res = ud->mb->mi->ROMBASE + 0x4000 * bank;
         #endif
         if(res)
             return &res[addr & 0x3FFF];

--- a/mi.h
+++ b/mi.h
@@ -43,6 +43,7 @@ struct mb_mi_cache
 struct mi_dispatch
 {
     const r8* __restrict const * __restrict ROM;
+    const r8* __restrict ROMBASE;
     r8* __restrict WRAM;
     r8* __restrict VRAM;
     r8* __restrict SRAM;

--- a/mi.h
+++ b/mi.h
@@ -43,7 +43,9 @@ struct mb_mi_cache
 struct mi_dispatch
 {
     const r8* __restrict const * __restrict ROM;
+    #if !CONFIG_ENABLE_LRU
     const r8* __restrict ROMBASE;
+    #endif
     r8* __restrict WRAM;
     r8* __restrict VRAM;
     r8* __restrict SRAM;

--- a/microcode.c
+++ b/microcode.c
@@ -2,6 +2,7 @@
 
 #include "microcode.h"
 #include "dbg.h"
+#include "fabric.h"
 
 
 #define self mb_state* __restrict mb
@@ -253,7 +254,7 @@ PGB_FUNC static word mch_memory_dispatch_read_fexx_ffxx(const self, word addr)
     }
     
     // Handle IO by fabric
-    return mb->mi->dispatch_IO(mb->mi->userdata, addr, 0, 0);
+    return pgf_cb_IO_(mb->mi->userdata, addr, 0, 0);
 }
 
 PGB_FUNC static void mch_memory_dispatch_write_fexx_ffxx(self, word addr, word data)
@@ -301,7 +302,7 @@ PGB_FUNC ATTR_HOT static word mch_memory_dispatch_read_(self, word addr)
         return *ptr;
     }
     
-    if(addr < 0xFE00)
+    if UNLIKELY(addr < 0xFE00)
     {
         addr -= 0x2000;
         goto wram_read;
@@ -1315,7 +1316,7 @@ PGB_FUNC ATTR_HOT word mb_exec(self)
             return 0;
         
         case 1: // MOV
-            if(IR != 0x76)
+            if LIKELY(IR != 0x76)
             {
                 instr_MOV:
                 {

--- a/microcode.c
+++ b/microcode.c
@@ -249,7 +249,7 @@ PGB_FUNC static word mch_memory_dispatch_read_fexx_ffxx(const self, word addr)
     {
         var hm = addr & 0xFF;
         
-        if(hm != 0xFF)
+        if LIKELY(hm != 0xFF)
         {
             USE_MI;
             
@@ -262,7 +262,7 @@ PGB_FUNC static word mch_memory_dispatch_read_fexx_ffxx(const self, word addr)
     }
     
     // Handle IO by fabric
-    return pgf_cb_IO_(mb->mi->userdata, addr, 0, 0);
+    return mb->mi->dispatch_IO(mb->mi->userdata, addr, 0, 0);
 }
 
 PGB_FUNC static void mch_memory_dispatch_write_fexx_ffxx(self, word addr, word data)
@@ -271,7 +271,7 @@ PGB_FUNC static void mch_memory_dispatch_write_fexx_ffxx(self, word addr, word d
     {
         var hm = addr & 0xFF;
         
-        if(hm != 0xFF)
+        if LIKELY(hm != 0xFF)
         {
             USE_MI;
             

--- a/pgb_main.h
+++ b/pgb_main.h
@@ -21,7 +21,7 @@ static inline word pgb_main_tick(mb_state* __restrict mb, vbool* ticked)
     else if(mb->HALTING)
     {
         if(!mb->IR.high)
-            mb->IR.high = 1
+            mb->IR.high = 1;
         
         if(ticked)
             *ticked = 0;

--- a/pgb_main.h
+++ b/pgb_main.h
@@ -18,16 +18,11 @@ static inline word pgb_main_tick(mb_state* __restrict mb, vbool* ticked)
         if(ticked)
             *ticked = 1;
     }
-    else if(mb->HALTING)
+    else // mb->HALTING
     {
         if(!mb->IR.high)
             mb->IR.high = 1;
         
-        if(ticked)
-            *ticked = 0;
-    }
-    else // ???
-    {
         if(ticked)
             *ticked = 0;
     }

--- a/types.h
+++ b/types.h
@@ -12,6 +12,19 @@
 //#define COMPILER_VARIABLE_BARRIER(var) (void)(var)
 #define COMPILER_VARIABLE_BARRIER(var) __asm volatile(""::"r"(var))
 
+#if defined(__GNUC__) || defined(__clang__)
+    #define LIKELY(x)   (__builtin_expect(!!(x), 1))
+    #define UNLIKELY(x) (__builtin_expect(!!(x), 0))
+#else
+    #define LIKELY(x)   (x)
+    #define UNLIKELY(x) (x)
+#endif
+
+#if defined(__GNUC__) || defined(__clang__)
+    #define LIKELY_P(x, p)   (__builtin_expect_with_probability(!!(x), 1, p))
+#else
+    #define LIKELY_P(x, p)   (x)
+#endif
 
 #if PPU_IS_MONOCHROME
 typedef unsigned char pixel_t;


### PR DESCRIPTION
summary (measured on _cv2: belmont's revenge_):
- ~5 fps gain from special casing PC < 0x8000 for `mch_memory_fetch_PC_2`
- ~1 fps gain from using arithmetic rather than double-indirect for accessing rom
- ~1 fps gain from pretending `jr $FE` costs an extra 20 cycles
- ~ 2 fps gain from using armclang instead of gcc 9.3 (not part of PR)

17 -> 26 fps in opening screen of cloud castle.

Also, I (hopefully) improved the performance of the timer. But cv2 doesn't use the timer, so I haven't checked.

I suggest squash-rebase